### PR TITLE
Feature/invited dashboard2

### DIFF
--- a/src/api/invitations/putInvitation.ts
+++ b/src/api/invitations/putInvitation.ts
@@ -2,7 +2,9 @@ import axiosInstance from '@/commons/lib/axiosInstance'
 import { PutInvitationType } from '@/types/invitations'
 import { InvitationType } from '@/types/invitedDashBoardListType'
 
-export const putInvitation = async ({ id, data }: PutInvitationType) => {
-  const response = await axiosInstance.put<InvitationType>(`/invitations/${id}`, data)
+export const putInvitation = async ({ id, inviteAccepted }: PutInvitationType) => {
+  const response = await axiosInstance.put<InvitationType>(`/invitations/${id}`, {
+    inviteAccepted,
+  })
   return response.data
 }

--- a/src/components/invitedDashBoard/InvitedDashBoard.module.scss
+++ b/src/components/invitedDashBoard/InvitedDashBoard.module.scss
@@ -1,7 +1,8 @@
 @import '@/styles/mixin.scss';
 
 section.container {
-  padding: 3.2rem 0;
+  width: fit-content;
+  padding-top: 3.2rem;
   border-radius: 8px;
   background: var(--color-white);
 
@@ -118,7 +119,9 @@ section.container {
 
     tbody {
       .invitation-item-container {
-        border-bottom: 1px solid #ccc;
+        &:not(:last-of-type) {
+          border-bottom: 1px solid var(--color-gray20);
+        }
         @include mobile {
           display: block;
           padding: 1.6rem;

--- a/src/components/invitedDashBoard/InvitedDashBoard.tsx
+++ b/src/components/invitedDashBoard/InvitedDashBoard.tsx
@@ -1,4 +1,4 @@
-import { useState, ChangeEvent, useEffect } from 'react'
+import { useState, ChangeEvent } from 'react'
 import styles from './InvitedDashBoard.module.scss'
 import useDebounce from '@/hooks/useDebounce'
 import { getInvitations } from '@/api/invitations/getInvitations'
@@ -21,9 +21,9 @@ interface InvitationsProps {
   invitationList: InvitationType[]
 }
 
-interface InvitedDashboardProps {
-  list: InvitationType[]
-}
+// interface InvitedDashboardProps {
+//   list: InvitationType[]
+// }
 
 const getInvitationsType = (
   debouncedSearchTitle: string,
@@ -74,7 +74,7 @@ function Invitations({ invitationList }: InvitationsProps) {
     mutationFn: putInvitation,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['getInvitations', ''],
+        queryKey: ['getInvitations'],
       })
     },
   })
@@ -120,7 +120,8 @@ function Invitations({ invitationList }: InvitationsProps) {
   ))
 }
 
-export default function InvitedDashBoard({ list }: InvitedDashboardProps) {
+export default function InvitedDashBoard() {
+  // { list }: InvitedDashboardProps
   const [searchTitle, setSearchTitle] = useState('')
   const debouncedSearchTitle = useDebounce(searchTitle, 1000)
 
@@ -131,7 +132,7 @@ export default function InvitedDashBoard({ list }: InvitedDashboardProps) {
 
   const invitationList = data
     ? data.invitations.filter((item: InvitationType) => !item.inviteAccepted)
-    : list
+    : []
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSearchTitle(event.target.value)

--- a/src/pages/mydashboard/index.tsx
+++ b/src/pages/mydashboard/index.tsx
@@ -9,30 +9,36 @@ export default function MyDashboardPage({ ...pageProps }) {
   return (
     <MyPageLayout title="mydashboard">
       <DashboardList />
-      <InvitedDashBoard list={pageProps.list} />
+      <InvitedDashBoard
+      // list={pageProps.list}
+      />
     </MyPageLayout>
   )
 }
 
-export async function getServerSideProps() {
-  try {
-    const { invitations } = await getInvitations()
+/**
+ * TODO
+ * getServerSideProps로 데이터 페치하고, InvitedDashBoard 컴포넌트 초기 렌더링 시 getInvitations 실행되지 않도록 useDidMountEffect 적용
+ */
+// export async function getServerSideProps() {
+//   try {
+//     const { invitations } = await getInvitations()
 
-    const newInvitedDashboardList: ReceivedInvitationsType['invitations'] = invitations.filter(
-      (item: InvitationType) => !item.inviteAccepted,
-    )
+//     const newInvitedDashboardList: ReceivedInvitationsType['invitations'] = invitations.filter(
+//       (item: InvitationType) => !item.inviteAccepted,
+//     )
 
-    return {
-      props: {
-        list: newInvitedDashboardList,
-      },
-    }
-  } catch (error) {
-    console.error('Error fetching data:', error)
-    return {
-      props: {
-        list: null,
-      },
-    }
-  }
-}
+//     return {
+//       props: {
+//         list: newInvitedDashboardList,
+//       },
+//     }
+//   } catch (error) {
+//     console.error('Error fetching data:', error)
+//     return {
+//       props: {
+//         list: null,
+//       },
+//     }
+//   }
+// }

--- a/src/types/invitations.ts
+++ b/src/types/invitations.ts
@@ -4,10 +4,6 @@ export interface InvitationsValue {
   email: string
 }
 
-export interface InvitedAcceptedType {
-  inviteAccepted: boolean
-}
-
 export interface ReceivedInvitationsType {
   cursorId: number
   invitations: InvitationType[] | []
@@ -15,5 +11,5 @@ export interface ReceivedInvitationsType {
 
 export type PutInvitationType = {
   id: number
-  data: InvitedAcceptedType
+  inviteAccepted: boolean
 }


### PR DESCRIPTION
## 개요
- 초대받은 대시보드 리팩토링
- 이슈 번호 : #10

## 작업 사항
- 리스트 불러오기, 검색, 수락, 거절 api useQuery, useMutation 적용
- 컴포넌트 너비 수정

## 스크린샷
<img width="772" alt="image" src="https://github.com/codeit-team-project/taskify/assets/82023300/8711cb3c-ab8f-49fe-b592-59be9f2f2235">

> 컴포넌트 너비 수정

# 리뷰어에게
- 기존에는, 컴포넌트 초기 렌더링 시에 getServerSideProps로 가져온 초기 데이터를 활용하고자 useDidMountEffect 훅을 만들어 활용했었는데, 이 부분은 리팩토링이 잘 되지 않아서 getServerSideProps를 유의미하게 사용하고 있지 않은 것 같습니다🥲

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
