### PR TITLE
[Feat] Feature/column modal - 컬럼 생성 모달

### DIFF
--- a/src/components/columns/columnModal/CreateColumnModal.module.scss
+++ b/src/components/columns/columnModal/CreateColumnModal.module.scss
@@ -1,0 +1,118 @@
+@import '@/styles/mixin.scss';
+
+.container {
+  padding: 2.8rem;
+  width: 54rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.8rem;
+  border-radius: 0.8rem;
+  background: var(--color-white);
+}
+
+.title {
+  padding: 0.4rem 0;
+  font-size: 2.4rem;
+  font-weight: 700;
+  color: var(--color-black_33);
+}
+
+.contents {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sub-title {
+  font-size: 1.8rem;
+  font-weight: 500;
+  color: var(--color-black_33);
+}
+
+.input {
+  padding: 1.5rem 1.6rem 1.4rem 1.6rem;
+  font-size: 1.6rem;
+  color: var(--color-black_33);
+  font-weight: 400;
+  border-radius: 0.6rem;
+  border: 1px solid var(--color-gray30);
+  background: var(--color-white);
+  outline: none;
+
+  &:focus {
+    border: 1px solid var(--color-primary);
+  }
+}
+
+.input-error {
+  border: 1px solid var(--color-red);
+}
+
+.errorMessage {
+  font-size: 1.4rem;
+  font-weight: 400;
+  color: var(--color-red);
+}
+
+.buttons {
+  display: flex;
+  gap: 1.2rem;
+  justify-content: flex-end;
+}
+
+@mixin button {
+  padding: 1.4rem 4.6rem;
+  font-size: 1.6rem;
+  font-weight: 500;
+  border-radius: 0.8rem;
+  background: var(--color-white);
+  outline: none;
+
+  @include mobile {
+    padding: 1.2rem 5.6rem;
+    font-size: 1.4rem;
+  }
+}
+
+.default-button {
+  @include button;
+  color: var(--color-gray50);
+  border: 1px solid var(--color-gray30);
+}
+
+.primary-button {
+  @include button;
+  color: var(--color-white);
+  background: var(--color-primary);
+}
+
+.inActive {
+  opacity: 0.7;
+  cursor: default;
+}
+
+@include mobile {
+  .container {
+    padding: 2rem;
+    width: 32.7rem;
+    gap: 2.4rem;
+  }
+
+  .title {
+    padding-top: 0.8rem;
+    font-size: 2rem;
+  }
+
+  .sub-title {
+    font-size: 1.6rem;
+  }
+
+  .input {
+    padding: 1.3rem 1.6rem 1.2rem 1.6rem;
+    font-size: 1.4rem;
+  }
+
+  .buttons {
+    justify-content: center;
+  }
+}

--- a/src/components/columns/columnModal/CreateColumnModal.tsx
+++ b/src/components/columns/columnModal/CreateColumnModal.tsx
@@ -1,0 +1,105 @@
+/**
+ * @TODO 컬럼 생성 모달
+ * 컬럼 생성 모달 UI (완료)
+ * UI 반응형 (완료)
+ * api 연동 (완료)
+ * 에러케이스 보여주기 (완료)
+ */
+import { ChangeEvent, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
+
+import styles from './CreateColumnModal.module.scss'
+import classNames from 'classnames'
+import { createColumn } from '@/api/columns/createColumn'
+import { getColumns } from '@/api/columns/getColumns'
+import { ColumnsType } from '@/types/columnsType'
+
+interface CreateColumnModalProps {
+  dashBoardId: number
+  onClose: () => void
+}
+
+export default function CreateColumnModal({ dashBoardId, onClose }: CreateColumnModalProps) {
+  const queryClient = useQueryClient()
+
+  const [inputValue, setInputValue] = useState('')
+
+  const { data } = useQuery<ColumnsType>({
+    queryKey: ['getColumns', dashBoardId],
+    queryFn: () => getColumns(dashBoardId),
+  })
+  console.log(data) // 삭제 예정
+
+  const {
+    mutate: createColumnMutation,
+    isPending,
+    isError,
+    error,
+  } = useMutation({
+    mutationKey: ['createColumn'],
+    mutationFn: createColumn,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['getColumns', dashBoardId],
+      })
+      onClose()
+    },
+  })
+
+  const errorMessage = (function () {
+    if (isError && error instanceof AxiosError) {
+      return error.response?.data.message ?? ''
+    }
+    return ''
+  })()
+
+  const handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value)
+  }
+  console.log(!inputValue.trim()) // 삭제 예정
+
+  const handleCreateInvitation = async () => {
+    const title = inputValue.trim()
+
+    if (!title || isPending) {
+      return
+    }
+
+    createColumnMutation({
+      title,
+      dashboardId: dashBoardId,
+    })
+  }
+
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>새 컬럼 생성</h2>
+      <div className={styles.contents}>
+        <p className={styles['sub-title']}>이름</p>
+        <input
+          className={classNames(styles.input, {
+            [styles['input-error']]: !!errorMessage,
+          })}
+          onChange={handleChangeInput}
+          value={inputValue}
+          placeholder="컬럼 이름을 입력해주세요"
+        />
+        {errorMessage && <p className={styles.errorMessage}>{errorMessage}</p>}
+      </div>
+      <div className={styles.buttons}>
+        <button className={styles['default-button']} onClick={() => onClose()}>
+          취소
+        </button>
+        <button
+          className={classNames(styles['primary-button'], {
+            [styles.inActive]: !inputValue.trim() || isPending,
+          })}
+          onClick={handleCreateInvitation}
+        >
+          생성
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/columns/columnModal/CreateColumnModal.tsx
+++ b/src/components/columns/columnModal/CreateColumnModal.tsx
@@ -1,16 +1,13 @@
 /**
  * @TODO 컬럼 생성 모달
- * 컬럼 생성 모달 UI (완료)
- * UI 반응형 (완료)
- * api 연동 (완료)
- * 에러케이스 보여주기 (완료)
+ * 모달 컨테이너로 감싸기
  */
 import { ChangeEvent, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
+import classNames from 'classnames'
 
 import styles from './CreateColumnModal.module.scss'
-import classNames from 'classnames'
 import { createColumn } from '@/api/columns/createColumn'
 import { getColumns } from '@/api/columns/getColumns'
 import { ColumnsType } from '@/types/columnsType'
@@ -30,10 +27,8 @@ export default function CreateColumnModal({ dashBoardId, onClose }: CreateColumn
     queryKey: ['getColumns', dashBoardId],
     queryFn: () => getColumns(dashBoardId),
   })
-  console.log(data) // 삭제 예정
 
   const columnsTitle = data?.data.map((column) => column.title)
-  console.log(columnsTitle) // 삭제 예정
 
   const {
     mutate: createColumnMutation,
@@ -62,7 +57,6 @@ export default function CreateColumnModal({ dashBoardId, onClose }: CreateColumn
       setErrorMessage('')
     }
   }
-  console.log(!inputValue.trim()) // 삭제 예정
 
   const handleCreateInvitation = async () => {
     const title = inputValue.trim()

--- a/src/components/columns/columnModal/CreateColumnModal.tsx
+++ b/src/components/columns/columnModal/CreateColumnModal.tsx
@@ -24,6 +24,7 @@ export default function CreateColumnModal({ dashBoardId, onClose }: CreateColumn
   const queryClient = useQueryClient()
 
   const [inputValue, setInputValue] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
 
   const { data } = useQuery<ColumnsType>({
     queryKey: ['getColumns', dashBoardId],
@@ -31,11 +32,13 @@ export default function CreateColumnModal({ dashBoardId, onClose }: CreateColumn
   })
   console.log(data) // 삭제 예정
 
+  const columnsTitle = data?.data.map((column) => column.title)
+  console.log(columnsTitle) // 삭제 예정
+
   const {
     mutate: createColumnMutation,
     isPending,
     isError,
-    error,
   } = useMutation({
     mutationKey: ['createColumn'],
     mutationFn: createColumn,
@@ -45,22 +48,29 @@ export default function CreateColumnModal({ dashBoardId, onClose }: CreateColumn
       })
       onClose()
     },
+    onError: (error) => {
+      if (isError && error instanceof AxiosError) {
+        return error.response?.data.message ?? ''
+      }
+    },
   })
-
-  const errorMessage = (function () {
-    if (isError && error instanceof AxiosError) {
-      return error.response?.data.message ?? ''
-    }
-    return ''
-  })()
 
   const handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value)
+
+    if (inputValue) {
+      setErrorMessage('')
+    }
   }
   console.log(!inputValue.trim()) // 삭제 예정
 
   const handleCreateInvitation = async () => {
     const title = inputValue.trim()
+
+    if (columnsTitle?.includes(title)) {
+      setErrorMessage('중복된 컬럼 이름입니다.')
+      return
+    }
 
     if (!title || isPending) {
       return

--- a/src/components/columns/columnModal/CreateColumnModal.tsx
+++ b/src/components/columns/columnModal/CreateColumnModal.tsx
@@ -26,15 +26,12 @@ export default function CreateColumnModal({ dashBoardId, onClose }: CreateColumn
   const { data } = useQuery<ColumnsType>({
     queryKey: ['getColumns', dashBoardId],
     queryFn: () => getColumns(dashBoardId),
+    enabled: !!dashBoardId,
   })
 
   const columnsTitle = data?.data.map((column) => column.title)
 
-  const {
-    mutate: createColumnMutation,
-    isPending,
-    isError,
-  } = useMutation({
+  const { mutate: createColumnMutation, isPending } = useMutation({
     mutationKey: ['createColumn'],
     mutationFn: createColumn,
     onSuccess: () => {
@@ -44,8 +41,8 @@ export default function CreateColumnModal({ dashBoardId, onClose }: CreateColumn
       onClose()
     },
     onError: (error) => {
-      if (isError && error instanceof AxiosError) {
-        return error.response?.data.message ?? ''
+      if (error instanceof AxiosError) {
+        setErrorMessage(error.response?.data.message)
       }
     },
   })
@@ -61,12 +58,12 @@ export default function CreateColumnModal({ dashBoardId, onClose }: CreateColumn
   const handleCreateInvitation = async () => {
     const title = inputValue.trim()
 
-    if (columnsTitle?.includes(title)) {
-      setErrorMessage('중복된 컬럼 이름입니다.')
+    if (!title || isPending) {
       return
     }
 
-    if (!title || isPending) {
+    if (columnsTitle?.includes(title)) {
+      setErrorMessage('중복된 컬럼 이름입니다.')
       return
     }
 


### PR DESCRIPTION
## 개요

- 칼럼 생성 모달 컴포넌트를 작업했습니다.
- #78 

## 작업 사항

- 칼럼 생성 모달 UI, 반응형 구현
- 칼럼 생성 기능 및 에러 UI

## 참고 사항 (optional)

- 모달 띄우는 부분은 공통 컴포넌트 merge 후에 작업 예정입니다.
- 모달 스타일을 공통 컴포넌트로 묶고(작은 모달 한정) 싶은데 프로젝트 끝나고 리팩토링 해보겠습니다.

## 스크린샷

![스크린샷 2023-12-31 오후 11 14 44](https://github.com/codeit-team-project/taskify/assets/124856726/08d77d97-fbdf-4703-825d-1436feb06512)

![image](https://github.com/codeit-team-project/taskify/assets/124856726/cc5c812a-f85c-49bc-a4ce-df986bdf415a)

![image](https://github.com/codeit-team-project/taskify/assets/124856726/7de732ce-e956-4901-9685-c9d37558079a)

### [default - 입력값 없을 때, 공백만 있을 때 비활성화]
![image](https://github.com/codeit-team-project/taskify/assets/124856726/3ed8a74c-c9e1-46fd-b488-9b247fdc1d59)

## 리뷰어에게

- 중복 타이틀 검증하는 부분을 ColumnList 컴포넌트에서 호출한 data를 title만 분리해서 배열로 만들어서 Prop으로 해당 모달까지 내려주고자 했는데요, 이 방법보다는 모달 컴포넌트에서 useQuery를 호출하는게 더 나을거라 판단하였습니다. 좋은 방법 있으시면 피드백 부탁드립니다.🤔
- 에러 메세지를 보여줄때 react-query의 error로 핸들링하고 싶었는데, 중복 검사는 따로 api가 존재하지 않아서 state를 만들 수 밖에 없었고, 이에 따라 state로 에러 메세지 핸들링을 했습니다.
- 새해에도 같이 코딩해요🔥

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
