### PR TITLE
Fix: 초대받은 대시보드 개선

### DIFF
--- a/src/components/invitedDashBoard/InvitedDashBoard.module.scss
+++ b/src/components/invitedDashBoard/InvitedDashBoard.module.scss
@@ -224,6 +224,7 @@ section.container {
   }
 
   div.no-invitation-container {
+    min-width: 102.2rem;
     display: grid;
     justify-content: center;
     justify-items: center;

--- a/src/components/invitedDashBoard/InvitedDashBoard.tsx
+++ b/src/components/invitedDashBoard/InvitedDashBoard.tsx
@@ -30,9 +30,9 @@ const getInvitationsType = (
   invitationList: InvitationType[],
 ): InvitationsStatus => {
   if (!debouncedSearchTitle) {
-    return invitationList && invitationList.length > 1 ? 'totalInvitations' : 'noInvitations'
+    return invitationList && invitationList.length >= 1 ? 'totalInvitations' : 'noInvitations'
   } else {
-    return invitationList && invitationList.length > 1
+    return invitationList && invitationList.length >= 1
       ? 'searchedInvitations'
       : 'noSearchedInvitations'
   }
@@ -94,7 +94,7 @@ function Invitations({ invitationList }: InvitationsProps) {
       </td>
       <td className={styles['inviter-name']}>
         <p className={styles['column-title']}>초대자</p>
-        {item.invitee.nickname}
+        {item.inviter.nickname}
       </td>
       <td className={styles['response']}>
         <div className={styles['button-container']}>

--- a/src/types/invitedDashBoardListType.ts
+++ b/src/types/invitedDashBoardListType.ts
@@ -11,6 +11,11 @@ export interface InvitationType {
     id: number
     email: string
   }
+  inviter: {
+    nickname: string
+    id: number
+    email: string
+  }
   inviteAccepted: boolean
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
## 개요
- 초대받은 대시보드 컴포넌트 보수
- #10 

## 작업 사항
- [x] 초대가 1개가 있을 때는 내역이 안보인다 -> 확인 및 수정
- [x] 초대자 이름에 초대받은 사람 이름이 보이는 것 같다 -> 기존 api 상에 inviter가 없어서 임시로 invitee를 붙여놨었네요. API 수정된 상태라 반영했습니다. 참고 : https://discord.com/channels/1141253983000866866/1141578393834504252/1188999129720959076
- [ ] 수락 or 거절을 하면 전체 리스트가 사라진다 -> 이 현상은 재현이 안되는 것 같습니다.

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
