### PR TITLE
Refactor: 공통 레이아웃 수정, 플로팅 버튼 위치 개선

### DIFF
--- a/src/components/columns/addColumnButton/AddColumnButton.module.scss
+++ b/src/components/columns/addColumnButton/AddColumnButton.module.scss
@@ -1,28 +1,37 @@
 @import '@/styles/mixin.scss';
 
-.button-container {
-  padding-top: 6.8rem;
-  button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 1.2rem;
-    width: 35.4rem;
-    height: 7rem;
-    border-radius: 8px;
-    border: 1px solid var(--color-gray30);
-    background-color: var(--color-white);
-    .button-text {
-      color: var(--color-black_33);
-      font-size: 1.8rem;
-      font-weight: 700;
-      line-height: 1;
-    }
+button.button-container {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.2rem;
+  width: 35.4rem;
+  height: 7rem;
+  padding: 0;
+  border-radius: 8px;
+  border: 1px solid var(--color-gray30);
+  background-color: var(--color-white);
+  .button-text {
+    color: var(--color-black_33);
+    font-size: 1.8rem;
+    font-weight: 700;
+    line-height: 1;
   }
+
   @include tablet {
-    padding-top: 2rem;
+    width: 100%;
+    left: 0;
+    bottom: 0;
+    transform: none;
     button {
       width: 100%;
+      border-radius: 0;
+      border: none;
+      border-top: 1px solid var(--color-gray30);
     }
   }
   @include mobile {

--- a/src/components/columns/addColumnButton/AddColumnButton.tsx
+++ b/src/components/columns/addColumnButton/AddColumnButton.tsx
@@ -22,12 +22,10 @@ export default function AddColumnButton({ dashBoardId }: AddColumnButtonProps) {
 
   return (
     <>
-      <li className={styles['button-container']}>
-        <button onClick={handleOpenModal}>
-          <p className={styles['button-text']}>새로운 컬럼 추가하기</p>
-          <img src="/assets/icon-add-purple.png" width={24} height={24} alt="추가 버튼 이미지" />
-        </button>
-      </li>
+      <button onClick={handleOpenModal} className={styles['button-container']}>
+        <p className={styles['button-text']}>새로운 컬럼 추가하기</p>
+        <img src="/assets/icon-add-purple.png" width={24} height={24} alt="추가 버튼 이미지" />
+      </button>
       {isOpenModal &&
         createPortal(
           <ModalContainer onClose={handleCloseModal}>

--- a/src/components/columns/columnList/ColumnList.module.scss
+++ b/src/components/columns/columnList/ColumnList.module.scss
@@ -2,13 +2,12 @@
 
 .column-list {
   display: flex;
-  overflow-x: scroll;
-  height: calc(100vh - 6rem);
+  background-color: var(--color-gray10);
+  height: 100%;
   > li {
     padding-left: 2rem;
     padding-right: 2rem;
     padding-bottom: 2rem;
-    background-color: var(--color-gray10);
     &:not(:last-of-type) {
       border-right: 2px solid var(--color-gray20);
     }

--- a/src/components/dashboardNav/floatingButton/FloatingButton.module.scss
+++ b/src/components/dashboardNav/floatingButton/FloatingButton.module.scss
@@ -7,7 +7,7 @@
   width: 5rem;
   height: 5rem;
   position: fixed;
-  bottom: 5rem;
+  bottom: 9rem;
   right: 5rem;
   border-radius: 8px;
   color: var(--color-white);
@@ -34,7 +34,7 @@
   flex-direction: column;
   gap: 1rem;
   position: fixed;
-  bottom: 13rem;
+  bottom: 16rem;
   right: 3rem;
   @keyframes dropdown {
     0% {

--- a/src/components/invitedDashBoard/InvitedDashBoard.module.scss
+++ b/src/components/invitedDashBoard/InvitedDashBoard.module.scss
@@ -128,7 +128,7 @@ section.container {
           padding: 1.6rem;
         }
         td {
-          padding: 2rem 1.6rem 2rem 0;
+          padding: 0 1.6rem 2rem 0;
           @include mobile {
             padding: 10rem;
           }

--- a/src/components/ui/layout/Layout.module.scss
+++ b/src/components/ui/layout/Layout.module.scss
@@ -1,20 +1,17 @@
 @import '@/styles/mixin.scss';
 
 .article-content {
-  margin: 7rem 0 0 30rem;
-  padding: 2rem;
-  height: calc(100vh - 7rem);
+  height: 100vh;
   background: var(--color-gray10);
   overflow: auto;
+  padding: 7rem 0 0 30rem;
 
   @include tablet {
-    margin: 7rem 0 0 16rem;
+    padding: 7rem 0 0 16rem;
   }
 
   @include mobile {
-    margin: 6rem 0 0 6.7rem;
-    padding: 1.2rem;
-    height: calc(100vh - 6rem);
+    padding: 6rem 0 0 6.7rem;
   }
 }
 

--- a/src/pages/dashboard/[id]/edit/index.module.scss
+++ b/src/pages/dashboard/[id]/edit/index.module.scss
@@ -4,6 +4,10 @@
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
+  padding: 2rem;
+  @include mobile {
+    padding: 1.2rem;
+  }
 }
 
 .action {

--- a/src/pages/my/index.module.scss
+++ b/src/pages/my/index.module.scss
@@ -1,0 +1,8 @@
+@import '@/styles/mixin.scss';
+
+.my-page-container {
+  padding: 2rem;
+  @include mobile {
+    padding: 1.2rem;
+  }
+}

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -6,13 +6,16 @@
 import MyPageLayout from '@/components/ui/layout/MypageLayout'
 import Profile from '@/components/editForm/profile/Profile'
 import PasswordModifier from '@/components/editForm/passwordModifier/PasswordModifier'
+import styles from './index.module.scss'
 
 export default function MyPage() {
   return (
     <>
       <MyPageLayout title="my">
-        <Profile />
-        <PasswordModifier />
+        <div className={styles['my-page-container']}>
+          <Profile />
+          <PasswordModifier />
+        </div>
       </MyPageLayout>
     </>
   )

--- a/src/pages/mydashboard/index.module.scss
+++ b/src/pages/mydashboard/index.module.scss
@@ -1,7 +1,7 @@
 @import '@/styles/mixin.scss';
 
 .container {
-  padding: 2rem;
+  padding: 4rem;
   display: flex;
   flex-direction: column;
   gap: 4.4rem;
@@ -11,7 +11,7 @@
   }
 
   @include mobile {
-    padding: 1.2rem;
+    padding: 2.4rem;
     gap: 2.4rem;
   }
 }


### PR DESCRIPTION
## 개요
- 레이아웃 정리
- 이슈 번호 : #97, #98
## 작업 사항
- 공통 마진 : 공통 패딩으로 변경하여 불필요한 세로 스크롤 제거했습니다.
- 공통 패딩 : 필요한 곳에서만 자체적으로 적용했습니다.
  > 내 대시보드 : 원래 자체적으로 padding 적용하고 있는 상태였습니다. (레이아웃과 패딩 중복 상태였으나, 레이아웃 패딩 제거해서 문제 해결됨)
  > 대시보드 관리 페이지 : 자체적으로 padding 적용했습니다
  > 계정 관리 페이지 : 자체적으로 padding 적용했습니다
- 새로운 컬럼 추가하기 버튼 : 데스크톱에서는 화면 중앙 하단에 fixed, 태블릿 부터는 화면 중앙 하단에 fixed 처리 했습니다.
- 모바일 플로팅 버튼(재원님이 작업해주신 버튼)을 3rem 위로 옮겼습니다. 

## 스크린샷
![image](https://github.com/codeit-team-project/taskify/assets/82023300/a047e984-aa7e-4f29-9ce5-987ee92499b4)

> 계정 관리 페이지 데스크톱 (대시보드 관리 페이지도 동일)

![image](https://github.com/codeit-team-project/taskify/assets/82023300/1e51102f-f5db-422b-bf97-fdfde01559f6)

> 계정 관리 페이지 모바일 (대시보드 관리 페이지도 동일)

![image](https://github.com/codeit-team-project/taskify/assets/82023300/a01450a1-5b76-4c63-bbff-6cdf5cfdde2f)

> 플로팅 버튼

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
