### PR TITLE
Feat: 초대받은 대시보드 무한 스크롤 구현

### DIFF
--- a/src/api/invitations/getInvitations.ts
+++ b/src/api/invitations/getInvitations.ts
@@ -1,10 +1,12 @@
 import axiosInstance from '@/commons/lib/axiosInstance'
 import { ReceivedInvitationsType } from '@/types/invitations'
 
-export const getInvitations = async (title?: string) => {
+export const getInvitations = async (title?: string, pageParam?: number | null) => {
   try {
-    const query = title ? `size=10&title=${title}` : 'size=10'
-    const response = await axiosInstance.get<ReceivedInvitationsType>(`/invitations?${query}`)
+    let query = ''
+    if (pageParam) query += `&cursorId=${pageParam}`
+    if (title) query += `&title=${title}`
+    const response = await axiosInstance.get<ReceivedInvitationsType>(`/invitations?size=6${query}`)
 
     return response.data
   } catch (error) {

--- a/src/api/invitations/getInvitations.ts
+++ b/src/api/invitations/getInvitations.ts
@@ -6,7 +6,7 @@ export const getInvitations = async (title?: string, pageParam?: number | null) 
     let query = ''
     if (pageParam) query += `&cursorId=${pageParam}`
     if (title) query += `&title=${title}`
-    const response = await axiosInstance.get<ReceivedInvitationsType>(`/invitations?size=6${query}`)
+    const response = await axiosInstance.get<ReceivedInvitationsType>(`/invitations?size=5${query}`)
 
     return response.data
   } catch (error) {

--- a/src/components/invitedDashBoard/InvitedDashBoard.module.scss
+++ b/src/components/invitedDashBoard/InvitedDashBoard.module.scss
@@ -1,7 +1,6 @@
 @import '@/styles/mixin.scss';
 
 section.container {
-  width: fit-content;
   max-height: 60rem;
   overflow-y: scroll;
   border-radius: 8px;
@@ -14,7 +13,7 @@ section.container {
   }
 
   @include mobile {
-    max-height: 83.6rem;
+    max-height: 50rem;
   }
 
   .column-title {
@@ -245,7 +244,6 @@ section.container {
   }
 
   div.no-invitation-container {
-    min-width: 102.2rem;
     display: grid;
     justify-content: center;
     justify-items: center;

--- a/src/components/invitedDashBoard/InvitedDashBoard.module.scss
+++ b/src/components/invitedDashBoard/InvitedDashBoard.module.scss
@@ -2,13 +2,19 @@
 
 section.container {
   width: fit-content;
-  padding-top: 3.2rem;
+  max-height: 60rem;
+  overflow-y: scroll;
   border-radius: 8px;
   background: var(--color-white);
   box-shadow: var(--box-shadow-md);
 
   @include tablet {
     width: 100%;
+    max-height: 59.2rem;
+  }
+
+  @include mobile {
+    max-height: 83.6rem;
   }
 
   .column-title {
@@ -23,19 +29,27 @@ section.container {
   }
 
   h2.title {
+    position: sticky;
+    top: 0;
+    height: 8.1rem;
+    padding-top: 3.2rem;
+    padding-bottom: 2rem;
     padding-left: 2.8rem;
+    background: var(--color-white);
     font-size: 2.4rem;
     font-weight: 700;
     color: var(--color-black_33);
     text-align: left;
     @include mobile {
+      height: 6.8rem;
+      padding-top: 2.4rem;
       padding-left: 1.6rem;
+      padding-left: 2rem;
       font-size: 2rem;
     }
   }
 
   table.invited-dashboard-table {
-    margin-top: 2rem;
     border-collapse: collapse;
     border-spacing: 0;
     @include tablet {
@@ -68,6 +82,12 @@ section.container {
       }
     }
     thead {
+      position: sticky;
+      top: 8.1rem;
+      background-color: var(--color-white);
+      @include mobile {
+        top: 6.8rem;
+      }
       .search-form-wrapper {
         padding: 0 2.8rem;
         @include mobile {
@@ -110,7 +130,7 @@ section.container {
           display: none;
         }
         th.column-title {
-          padding: 2.4rem 0;
+          padding-top: 2.4rem;
           &:first-of-type {
             padding-left: 2.8rem;
           }
@@ -118,7 +138,7 @@ section.container {
       }
     }
 
-    tbody {
+    tbody.column-body {
       .invitation-item-container {
         &:not(:last-of-type) {
           border-bottom: 1px solid var(--color-gray20);
@@ -232,6 +252,7 @@ section.container {
     gap: 2.4rem;
     padding: 6.6rem 0 12.8rem 0;
     @include tablet {
+      min-width: unset;
       width: 100%;
     }
     @include mobile {

--- a/src/hooks/useScroll.tsx
+++ b/src/hooks/useScroll.tsx
@@ -6,18 +6,22 @@ const useScroll = () => {
   const myRef = useRef(null)
 
   const observer = useMemo(() => {
-    return new IntersectionObserver((entries) => {
-      const entry = entries[0]
-      setIsVisible(entry.isIntersecting)
-    })
-  }, [])
+    if (typeof window !== 'undefined') {
+      return new IntersectionObserver((entries) => {
+        const entry = entries[0]
+        setIsVisible(entry.isIntersecting)
+      })
+    }
+  }, [typeof window])
 
   useEffect(() => {
-    if (myRef.current) {
+    if (myRef.current && observer !== undefined) {
       observer.observe(myRef.current)
     }
     return () => {
-      observer.disconnect()
+      if (observer !== undefined) {
+        observer.disconnect()
+      }
     }
   }, [myRef.current])
 

--- a/src/types/invitations.ts
+++ b/src/types/invitations.ts
@@ -5,7 +5,7 @@ export interface InvitationsValue {
 }
 
 export interface ReceivedInvitationsType {
-  cursorId: number
+  cursorId: any
   invitations: InvitationType[] | []
 }
 


### PR DESCRIPTION
## 개요
- 초대받은 대시보드 무한 스크롤 관련 + a
- 이슈 번호 : #72
- 해당 PR에 대한 리뷰어와 라벨을 생성해 주세요.

## 작업 사항
- 무한 스크롤 (한번에 5개 씩)
- 테이블 세로 스크롤 처리 + 테이블 상단 영역 고정 + 컴포넌트 최대 높이 제한(화면 안에 다 들어오는 높이로 제한)

## 참고 사항 (optional)
- 연아님 #112 PR에 포함된 useScroll 수정본이 필요하여 가져다 사용하였습니다.
- 컴포넌트 내부에 세로 스크롤이 생기게 한 이유는 스크롤을 해도 검색창과 컴포넌트 타이틀이 계속 보이게 하기 위해 해당 영역을 고정하기 위해서 입니다.

## 스크린샷
https://github.com/codeit-team-project/taskify/assets/82023300/ac082ba1-6207-429d-a1dc-9dc6791fd573

## 리뷰어에게
- 리뷰 대환영입니다❤️‍🔥

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
