### PR TITLE
Fix: 스크롤 바닥 인지 못하는 현상 해결

### DIFF
--- a/src/components/invitedDashBoard/InvitedDashBoard.module.scss
+++ b/src/components/invitedDashBoard/InvitedDashBoard.module.scss
@@ -276,3 +276,7 @@ section.container {
     }
   }
 }
+
+.end {
+  color: transparent;
+}

--- a/src/components/invitedDashBoard/InvitedDashBoard.module.scss
+++ b/src/components/invitedDashBoard/InvitedDashBoard.module.scss
@@ -278,5 +278,6 @@ section.container {
 }
 
 .end {
+  height: 0;
   color: transparent;
 }

--- a/src/components/invitedDashBoard/InvitedDashBoard.tsx
+++ b/src/components/invitedDashBoard/InvitedDashBoard.tsx
@@ -220,6 +220,7 @@ export default function InvitedDashBoard() {
         </table>
       )}
       <div ref={myRef}></div>
+      <div className={styles.end}>end</div>
     </section>
   )
 }


### PR DESCRIPTION
## 개요
- 인피니트 스크롤 바닥 인지 못하는 현상 해결

## 작업 사항
- 인피니트 스크롤 바닥 인지 못하는 현상 해결


## 참고 사항 (optional)
- `<div className={styles.end}>end</div>` 이런 요소를 맨 아래에 두고, 시각적으로는 보이지 않게 처리해서 문제는 해결되었지만, 인과관계를 정확히 모르겠습니다. 멘토님 혹시 도움 주실 수 있으실까용?


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
